### PR TITLE
Long polling - add delay between polling

### DIFF
--- a/NchanSubscriber.js
+++ b/NchanSubscriber.js
@@ -929,8 +929,8 @@
 
       Longpoll.prototype.reschedulePendingPollRequest = function(pollDelay) {
         this.opt.pollDelay = pollDelay;
-        if (this.nextRequestTimer) {
-            this.cancelPendingPollRequest();
+        this.cancelPendingPollRequest();
+        if (!this.req) {
             this.pollingRequest();
         }
       };

--- a/NchanSubscriber.js
+++ b/NchanSubscriber.js
@@ -845,16 +845,16 @@
           else if((code == 0 && response_text == "Error" && req.readyState == 4) || (code === null && response_text != "Abort")) {
             //console.log("abort!!!");
             this.emit("__disconnect", code || 0, response_text);
-            delete this.req;
+            this.cancel();
           }
           else if(code !== null) {
             //HTTP error
             this.emit("error", code, response_text);
-            delete this.req;
+            this.cancel();
           }
           else {
             //don't care about abortions 
-            delete this.req;
+            this.cancel();
             this.emit("__disconnect");
             //console.log("abort!");
           }

--- a/NchanSubscriber.js
+++ b/NchanSubscriber.js
@@ -931,9 +931,11 @@
 
       Longpoll.prototype.reschedulePendingPollRequest = function(pollDelay) {
         this.opt.longpoll.pollDelay = pollDelay;
-        this.cancelPendingPollRequest();
-        if (!this.req) {
+        this.cancel();
+        if (this.opt.longpoll.pollDelay === 0) {
             this.pollingRequest();
+        } else {
+          this.nextRequestTimer = global.setTimeout(this.pollingRequest, this.opt.longpoll.pollDelay);
         }
       };
       

--- a/NchanSubscriber.js
+++ b/NchanSubscriber.js
@@ -19,7 +19,7 @@
  *   // subscriberName is a string
  *   //
  *   // longpoll transport supports;
- *   //   opt.pollDelay - time in milliseconds before starting the next request after the current requests finishes
+ *   //   opt.longpoll.pollDelay - time in milliseconds before starting the next request after the current requests finishes
  * });
  * 
  * sub.on("transportNativeCreated", function(nativeTransportObject, subscriberName) {
@@ -783,8 +783,10 @@
         this.opt = {
           url: null,
           msgid: null,
-          pollDelay: 0,
           headers : {
+          },
+          longpoll: {
+              pollDelay: 0,
           }
         }
       }
@@ -833,10 +835,10 @@
             }
             
             if (this.req) { //this check is needed because stop() may have been called in the message callback
-              if (this.opt.pollDelay == 0) {
+              if (this.opt.longpoll.pollDelay == 0) {
                 this.pollingRequest();
               } else {
-                this.nextRequestTimer = global.setTimeout(this.pollingRequest, this.opt.pollDelay);
+                this.nextRequestTimer = global.setTimeout(this.pollingRequest, this.opt.longpoll.pollDelay);
               }
             }
           }
@@ -928,7 +930,7 @@
       };
 
       Longpoll.prototype.reschedulePendingPollRequest = function(pollDelay) {
-        this.opt.pollDelay = pollDelay;
+        this.opt.longpoll.pollDelay = pollDelay;
         this.cancelPendingPollRequest();
         if (!this.req) {
             this.pollingRequest();

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ opt = {
 sub.on("transportSetup", function(opt, subscriberName) {
   // opt is a hash/object - not all transports support all options equally. Only longpoll supports arbitrary headers
   // subscriberName is a string
+  //
+  // longpoll transport supports;
+  //   opt.pollDelay - time in milliseconds before starting the next request after the current requests finishes
 });
 
 sub.on("transportNativeCreated", function(nativeTransportObject, subscriberName) {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sub.on("transportSetup", function(opt, subscriberName) {
   // subscriberName is a string
   //
   // longpoll transport supports;
-  //   opt.pollDelay - time in milliseconds before starting the next request after the current requests finishes
+  //   opt.longpoll.pollDelay - time in milliseconds before starting the next request after the current requests finishes
 });
 
 sub.on("transportNativeCreated", function(nativeTransportObject, subscriberName) {


### PR DESCRIPTION
Add's a configurable delay between polling, and support for changing the polling period without a full stop/start cycle.

I'm not sure if this is the best way to implement `reschedulePendingPollRequest`, but the entire polling period bit is entirely specific to the long poll transport type.